### PR TITLE
Fix spaces between values in cost migration.

### DIFF
--- a/modules/localgov_outpost_connector/config/migration_base/migration.localgov_outpost_services.yml
+++ b/modules/localgov_outpost_connector/config/migration_base/migration.localgov_outpost_services.yml
@@ -23,6 +23,7 @@ source:
     CURRENCY: '£'
     COLON: ':'
     EMPTY: ''
+    SPACE: ' '
   fields:
     -
       name: id
@@ -188,10 +189,11 @@ process:
         plugin: concat
         source:
           - option
+          - source/constants/SPACE
           - source/constants/CURRENCY
           - amount
+          - source/constants/SPACE
           - cost_type
-        delimiter: ''
   localgov_outpost_regular_sched:
     plugin: sub_process
     source: regular_schedules


### PR DESCRIPTION
This seems to work, thanks @ekes !